### PR TITLE
Use local caching

### DIFF
--- a/registry/pkg/adapter/adapter.go
+++ b/registry/pkg/adapter/adapter.go
@@ -122,9 +122,13 @@ func (a *registryAdapter) loadCachedTagDigests() {
 	content, err := ioutil.ReadFile(a.cacheFile)
 	if err != nil {
 		// Couldn't read the cache. We'll just continue without cached data.
+		a.logger.Warnf("Failed to read cache file: %s", err.Error())
 		return
 	}
-	json.Unmarshal(content, &a.digestCache)
+	err = json.Unmarshal(content, &a.digestCache)
+	if err != nil {
+		a.logger.Warnf("Failed to unmarshal cached digests: %s", err.Error())
+	}
 }
 
 func (a *registryAdapter) saveCachedTagDigests() {

--- a/registry/pkg/reconciler/source/resources/deployment.go
+++ b/registry/pkg/reconciler/source/resources/deployment.go
@@ -34,6 +34,8 @@ type ServiceArgs struct {
 	Source              *sourcesv1alpha1.RegistrySource
 }
 
+const StateMountPath string = "/state"
+
 // MakeDeployment generates, but does not create, a Deployment for the given
 // RegistrySource.
 func MakeDeployment(args *ServiceArgs) (*appsv1.Deployment, error) {
@@ -104,10 +106,24 @@ func MakeDeployment(args *ServiceArgs) (*appsv1.Deployment, error) {
 				Spec: corev1.PodSpec{
 					ServiceAccountName: args.Source.Spec.ServiceAccountName,
 					Containers: []corev1.Container{{
-						Name: "registry-poller",
+						Name:  "registry-poller",
 						Image: args.ReceiveAdapterImage,
 						Env:   env,
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								MountPath: StateMountPath,
+								Name:      "state-volume",
+							},
+						},
 					}},
+					Volumes: []corev1.Volume{
+						{
+							Name: "state-volume",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Update to use cache the digests on the pod. This prevents pod restarts from triggering new events.

In the case where the pod is deleted `kc delete pod ...` the cache will be cleared out and a new event will be invoked. 